### PR TITLE
Add eslint-plugin-mocha, prettier

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,9 +14,22 @@ module.exports = {
     es6: true
   },
 
-  extends: 'eslint:recommended',
+  plugins: [
+    'mocha'
+  ],
+
+  extends: [
+    'eslint:recommended',
+    'plugin:mocha/recommended'
+  ],
 
   rules: {
+    'mocha/no-hooks-for-single-case': 0,
+    'mocha/no-mocha-arrows': 0,
+    'mocha/no-pending-tests': 0,
+    'mocha/no-skipped-tests': 0,
+    'mocha/prefer-arrow-callback': 2,
+
     'arrow-spacing': 2,
     'keyword-spacing': 2,
     'constructor-super': 2,

--- a/index.js
+++ b/index.js
@@ -20,7 +20,8 @@ module.exports = {
 
   extends: [
     'eslint:recommended',
-    'plugin:mocha/recommended'
+    'plugin:mocha/recommended',
+    'plugin:prettier/recommended'
   ],
 
   rules: {
@@ -29,6 +30,8 @@ module.exports = {
     'mocha/no-pending-tests': 0,
     'mocha/no-skipped-tests': 0,
     'mocha/prefer-arrow-callback': 2,
+
+    "prettier/prettier": ["error", { "singleQuote": true }],
 
     'arrow-spacing': 2,
     'keyword-spacing': 2,
@@ -68,7 +71,6 @@ module.exports = {
       }
     }],
     'linebreak-style': [2, 'unix'],
-    'max-len': [2, 80, 4],
     'new-cap': 2,
     'new-parens': 2,
     'no-alert': 2,
@@ -103,7 +105,14 @@ module.exports = {
     'no-void': 2,
     'object-curly-spacing': [2, 'always'],
     'operator-linebreak': [2, 'before'],
-    'quotes': [2, 'single'],
+    // 'quotes' adjusted to work well with prettier
+    // https://github.com/prettier/eslint-config-prettier#quotes
+    // https://eslint.org/docs/rules/quotes
+    'quotes': [
+      'error',
+      'single',
+      { 'avoidEscape': true, 'allowTemplateLiterals': false }
+    ]
     'quote-props': [2, 'as-needed'],
     radix: 2,
     semi: [2, 'always'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-7Izs0/eNTMhIO6m0Zt+bfN7KAnfAyPDI4DD89qeeWVVeWTsWliGtC5dGh6YIz7gfX3ByWGrYFTG+p9NrMnVo1Q==",
       "dev": true,
       "requires": {
-        "detect-indent": "5.0.0",
-        "editor": "1.0.0",
-        "minimist": "1.2.0"
+        "detect-indent": "^5.0.0",
+        "editor": "^1.0.0",
+        "minimist": "^1.2.0"
       },
       "dependencies": {
         "editor": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
   },
   "peerDependencies": {
     "eslint": "^6.8.0",
-    "eslint-plugin-mocha": "^6.3.0"
+    "eslint-plugin-mocha": "^6.3.0",
+    "eslint-plugin-prettier": "^3.1.2",
+    "eslint-config-prettier": "^6.10.0",
+    "prettier": "^1.19.1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "@studio/changes": "^1.0.0"
   },
   "peerDependencies": {
-    "eslint": "^6.8.0"
+    "eslint": "^6.8.0",
+    "eslint-plugin-mocha": "^6.3.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   "devDependencies": {
     "@studio/changes": "^1.0.0"
   },
+  "peerDependencies": {
+    "eslint": "^6.8.0"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/javascript-studio/studio-eslint-config.git"


### PR DESCRIPTION
This PR adds two eslint plugins:

* eslint-plugin-mocha
* prettier (and eslint-config-prettier, eslint-plugin-prettier)

#### How to verify

1. Check out this branch
1. `npm link`
1. In a consuming project:
    1. `npm install eslint-plugin-mocha prettier eslint-config-prettier eslint-plugin-prettier`
    1. `npm link @studio/eslint-config`
    1. `npm run lint`
1. Observe the new lint violations