### PR TITLE
Allow early use of functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ module.exports = {
     'no-unneeded-ternary': 2,
     'no-unused-expressions': 2,
     'no-unused-vars': [2, { args: 'after-used', argsIgnorePattern: '^_' }],
-    'no-use-before-define': 2,
+    'no-use-before-define': ['error', { 'functions': false, 'classes': true }]
     'no-useless-call': 2,
     'no-useless-concat': 2,
     'no-void': 2,


### PR DESCRIPTION
This PR updates the configuration to allow using hoisted functions.

Once merged, I'll create a separate branch from c641c01cb45982ead23d6b9851aa835f596a12e2 and add this commit to it. This will allow us to cut a `minor` release of `1.x`, which we can use immediately.

#### Background

Function declarations are hoisted, so early use of functions (before
they're declared) is safe.

This allows organisation of code to read like a newspaper article, i.e.
from higher to lower abstraction level, which is recommended by people
like Robert C. Martin (Clean Code) and Kent C. Dodds.

See:
  * https://eslint.org/docs/rules/no-use-before-define#options
  * https://books.google.es/books?id=_i6bDeoCQzsC&pg=PA136&lpg=PA136&dq=code+read+like+a+newspaper+article&source=bl&ots=epaNGi4a19&sig=ACfU3U1J0a7UzLLelJBJVgfENXgKxfNalw&hl=en&sa=X&ved=2ahUKEwjTkOfsv5LoAhWiyoUKHdlgAeEQ6AEwAnoECAoQAQ#v=onepage&q=code%20read%20like%20a%20newspaper%20article&f=false
  * https://kentcdodds.com/blog/newspaper-code-structure