### PR TITLE
ESLint 8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@studio/changes": "^2.2.0"
       },
       "peerDependencies": {
-        "eslint": "^7",
+        "eslint": "^7 || ^8",
         "eslint-plugin-mocha": "^8 || ^9",
         "eslint-plugin-node": "^11"
       }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "author": "Maximilian Antoni <max@javascript.studio>",
   "homepage": "https://github.com/javascript-studio/eslint-config",
   "scripts": {
+    "test": "eslint --config index.js index.js",
+    "preversion": "npm test",
     "version": "changes --commits --footer",
     "postversion": "git push --follow-tags && npm publish"
   },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@studio/changes": "^2.2.0"
   },
   "peerDependencies": {
-    "eslint": "^7",
+    "eslint": "^7 || ^8",
     "eslint-plugin-mocha": "^8 || ^9",
     "eslint-plugin-node": "^11"
   },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "peerDependencies": {
     "eslint": "^7 || ^8",
-    "eslint-plugin-mocha": "^8 || ^9",
+    "eslint-plugin-mocha": "^8 || ^9 || ^10",
     "eslint-plugin-node": "^11"
   },
   "repository": {


### PR DESCRIPTION
~⚠️ Upgrading to ESLint 8 is currently blocked because the `eslint-plugin-node` peer dependency does not support it yet.~